### PR TITLE
Adds TextStyle definitions for use in the connected state for display

### DIFF
--- a/app/src/main/java/com/garan/wearwind/screens/Loading.kt
+++ b/app/src/main/java/com/garan/wearwind/screens/Loading.kt
@@ -51,7 +51,7 @@ fun WearwindLoadingMessage(
     showBackground = WEAR_PREVIEW_SHOW_BACKGROUND
 )
 @Composable
-fun PreviewLoadingScreen() {
+fun LoadingScreenPreview() {
     val uiState = rememberUiState()
     WearwindLoadingMessage(
         uiState = uiState,

--- a/app/src/main/java/com/garan/wearwind/ui/theme/MetricTypography.kt
+++ b/app/src/main/java/com/garan/wearwind/ui/theme/MetricTypography.kt
@@ -1,0 +1,33 @@
+package com.garan.wearwind.ui.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+/**
+ * Holds definitions of text styling for the main Wearwind displays when connected. As these labels
+ * don't fit into the existing [Typography] semantic definitions, these additional names are defined
+ * as opposed to trying to somehow reuse/misuse Title1 etc.
+ */
+data class MetricTypography(
+    val largeDisplayMetric: TextStyle = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.ExtraBold,
+        fontStyle = FontStyle.Italic,
+        fontSize = 108.sp
+    ),
+    val mediumDisplayMetric: TextStyle = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.ExtraBold,
+        fontStyle = FontStyle.Italic,
+        fontSize = 64.sp
+    ),
+    val smallDisplayMetric: TextStyle = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.ExtraBold,
+        fontStyle = FontStyle.Italic,
+        fontSize = 48.sp
+    )
+)


### PR DESCRIPTION
Adds TextStyle definitions for displaying the large Speed and HR labels.

Also considered:
- Using [Typography]: The semantic definitions in Typography did not seem a good fit, so it felt better to keep this separate.
- Using Local Composition, for the Connected screen and sub elements. However, this felt like overkill.