### PR TITLE
Removes last remaining use of ConstraintLayout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.garan.wearwind"
         minSdkVersion 30
         targetSdkVersion 30
-        versionCode 12
-        versionName "2.2.1"
+        versionCode 13
+        versionName "2.2.2"
         vectorDrawables {
             useSupportLibrary true
         }
@@ -60,8 +60,6 @@ dependencies {
     // Only required for circular progress indicator
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
-
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.0-rc02"
 
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
 

--- a/app/src/main/java/com/garan/wearwind/screens/Connect.kt
+++ b/app/src/main/java/com/garan/wearwind/screens/Connect.kt
@@ -1,5 +1,9 @@
 package com.garan.wearwind.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,18 +14,15 @@ import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ChainStyle
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.ConstraintSet
 import androidx.lifecycle.Lifecycle
 import androidx.wear.compose.material.Button
-import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import com.garan.wearwind.FanControlService
@@ -35,7 +36,6 @@ import com.garan.wearwind.ui.theme.WearwindTheme
 /**
  * Composable functions used on the Connect screen, for initiating a connection to the fan.
  */
-@OptIn(ExperimentalWearMaterialApi::class)
 @Composable
 fun ConnectScreen(
     hrEnabled: Boolean = false,
@@ -59,67 +59,37 @@ fun ConnectScreen(
         }
     }
 
-    val constraintSet = ConstraintSet {
-        val connectButton = createRefFor("connectButton")
-        val hrButton = createRefFor("hrButton")
-        val settingsButton = createRefFor("settingsButton")
-        val progressIndicator = createRefFor("progress")
-
-        constrain(progressIndicator) {
-            top.linkTo(parent.top)
-            bottom.linkTo(parent.bottom)
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-        }
-        constrain(connectButton) {
-            top.linkTo(parent.top)
-            bottom.linkTo(settingsButton.top)
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-        }
-        constrain(hrButton) {
-            top.linkTo(settingsButton.top)
-            bottom.linkTo(settingsButton.bottom)
-            start.linkTo(parent.start)
-            end.linkTo(settingsButton.start)
-        }
-        constrain(settingsButton) {
-            top.linkTo(connectButton.bottom)
-            bottom.linkTo(parent.bottom)
-            start.linkTo(hrButton.end)
-            end.linkTo(parent.end)
-        }
-        createVerticalChain(
-            connectButton,
-            settingsButton,
-            chainStyle = ChainStyle.Packed
-        )
-    }
-
-    ConstraintLayout(constraintSet = constraintSet, modifier = Modifier.fillMaxSize()) {
-        ConnectionIndicator(connectionStatus)
-        ConnectButton(
-            modifier = Modifier
-                .layoutId("connectButton")
-                .padding(16.dp),
-            connectionStatus,
-            onClick = onConnectClick
-        )
-        Button(
-            onClick = onSettingsClick,
-            modifier = Modifier.layoutId("settingsButton"),
-            enabled = connectionStatus == FanControlService.FanConnectionStatus.DISCONNECTED
+    ConnectionIndicator(connectionStatus)
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(
-                imageVector = Icons.Rounded.Settings,
-                stringResource(id = R.string.settings)
-            )
+            Row {
+                ConnectButton(
+                    modifier = Modifier
+                        .padding(16.dp),
+                    connectionStatus,
+                    onClick = onConnectClick
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                HrButton(
+                    connectionStatus,
+                    hrEnabled = hrEnabled,
+                    onClick = onHrClick
+                )
+                SettingsButton(
+                    onClick = onSettingsClick,
+                    enabled = connectionStatus == FanControlService.FanConnectionStatus.DISCONNECTED
+                )
+            }
         }
-        HrButton(
-            connectionStatus,
-            hrEnabled = hrEnabled,
-            onClick = onHrClick
-        )
     }
 }
 
@@ -156,6 +126,23 @@ fun ConnectionIndicator(connectionStatus: FanControlService.FanConnectionStatus)
                 .layoutId("progress")
                 .fillMaxSize(),
             color = Colors.primary
+        )
+    }
+}
+
+@Composable
+fun SettingsButton(
+    onClick: () -> Unit,
+    enabled: Boolean
+) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier.layoutId("settingsButton"),
+        enabled = enabled
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Settings,
+            stringResource(id = R.string.settings)
         )
     }
 }

--- a/app/src/main/java/com/garan/wearwind/screens/Connected.kt
+++ b/app/src/main/java/com/garan/wearwind/screens/Connected.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight


### PR DESCRIPTION
`Connect` screen is using `ConstraintLayout`, but this isn't necessary - simplifies through use of `Box`, `Column` and `Row`.